### PR TITLE
update tensorflow and markuputils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,9 @@ setup(
 	install_requires=['absl-py==0.3.0', 'astor==0.7.1', 'bleach==1.5.0', 'click==6.7',
 	                  'cycler==0.10.0', 'dateparser@git+https://github.com/scrapinghub/dateparser.git@a01a4d2071a8f1d4b368543e5e09cde5eb880799', 'Flask==1.0.2', 'gast==0.2.0', 'grpcio==1.14.0', 'h5py==2.8.0',
 	                  'html5lib==0.9999999', 'itsdangerous==0.24', 'Jinja2==2.10', 'Keras==2.2.0',
-	                  'kiwisolver==1.0.1', 'Markdown==2.6.11', 'MarkupSafe==1.0', 'matplotlib==2.2.2', 'nose==1.3.7', 'numpy==1.15.1',
+	                  'kiwisolver==1.0.1', 'Markdown==2.6.11', 'MarkupSafe==1.1.1', 'matplotlib==2.2.2', 'nose==1.3.7', 'numpy==1.15.1',
 	                  'pandas==0.23.3', 'protobuf==3.6.0', 'pyparsing==2.2.0', 'python-dateutil==2.7.3', 'pytz==2018.5', 'python-Levenshtein',
 	                  'PyYAML==3.13', 'scikit-learn==0.19.2', 'scipy==1.1.0', 'six==1.11.0',
-	                  'sklearn==0.0', 'tensorflow==1.5', 'termcolor==1.1.0',
+	                  'sklearn==0.0', 'tensorflow==1.5.1', 'termcolor==1.1.0',
 	                  'Werkzeug==0.14.1', 'keras-contrib@git+https://www.github.com/keras-team/keras-contrib.git@f25c26665e990cfdf1da61a3de10a34d67f74b37'],
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", 'r') as f:
 
 setup(
 	name='Quagga',
-	version='1.0',
+	version='1.0.1',
 	description='An email segmentation system',
 	license="GPL",
 	long_description=long_description,


### PR DESCRIPTION
fixes https://github.com/HPI-Information-Systems/QuaggaLib/issues/17.
the lib is useable with python 3.6 again. As you can see in the CI, newer python versions do not work because we can't (easily) install tensorflow 1.5 there.